### PR TITLE
feature: Add support for Yang features

### DIFF
--- a/config/ietf-routing.toml
+++ b/config/ietf-routing.toml
@@ -4,7 +4,6 @@ prefix = "ietf_rt"
 [yang.modules]
 main = "ietf-routing"
 other = ["ietf-ipv4-unicast-routing", "ietf-ipv6-unicast-routing"]
-# TODO: add feature selection support
 features = ["router-id"]
 
 [yang.types]

--- a/src/core/config.py
+++ b/src/core/config.py
@@ -1,9 +1,10 @@
-from typing import Dict, Any, List
+from typing import Dict, Any, List, Optional
 
 
 class YangModulesConfiguration:
     main_module: str
     other_modules: List[str] = []
+    features: Optional[List[str]] = None
 
     def __init__(self, config: Dict[str, Any]) -> None:
         assert ("main" in config)
@@ -13,11 +14,17 @@ class YangModulesConfiguration:
         if "other" in config:
             self.other_modules = config["other"]
 
+        if "features" in config:
+            self.features = config["features"]
+
     def get_main_module(self) -> str:
         return self.main_module
 
     def get_other_modules(self) -> List[str]:
         return self.other_modules
+
+    def get_features(self) -> Optional[List[str]]:
+        return self.features
 
 
 class YangPrefixConfiguration:


### PR DESCRIPTION
If 'features' list in [yang.modules] in config file
- is not defined then all features are enabled (as before).
- is defined as an empty list then all features are disabled.
- is defined as a list of features then only those features are enabled.